### PR TITLE
feat: implement issue #9 battle situation core APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ This web app does not need responsive design and is intended for desktop use onl
 - `src/shared`: Reusable code outside business logic.
 - `src/providers`: Providers for specific libraries (for example, TanStack).
 
+# Planning Reference Rule
+When creating an implementation plan, always review the PRD and proposal documents under `docs/` first.
+
 # Docs Update Rule
 When updating `README.md` or files under `docs/` after resolving an issue, do not mention issue numbers unless explicitly instructed to reference a specific issue.
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,21 @@ pnpm start
 pnpm lint
 pnpm test
 pnpm prisma:generate
-pnpm prisma:migrate --name init
+pnpm prisma:migrate
+pnpm prisma:migrate:deploy
 pnpm prisma:seed
 ```
+
+## Supabase 전용 마이그레이션 워크플로우
+
+이 프로젝트는 Supabase DB만 사용하는 운영을 기준으로, `migrate dev` 대신 `migrate deploy`를 사용합니다.
+
+1. `.env`에 Supabase 연결 문자열(`DATABASE_URL`, `DIRECT_URL`)을 설정합니다.
+2. `pnpm prisma:generate`를 실행합니다.
+3. `pnpm prisma:migrate`(=`prisma migrate deploy`)를 실행해 `prisma/migrations`의 SQL을 적용합니다.
+4. 필요 시 `pnpm prisma:seed`를 실행합니다.
+
+새 스키마 변경이 필요할 때는 `prisma/migrations/<timestamp>_<name>/migration.sql`을 직접 추가한 뒤 `migrate deploy`로 반영합니다.
 
 ## 문서
 

--- a/docs/auth-and-access-foundation.md
+++ b/docs/auth-and-access-foundation.md
@@ -75,14 +75,11 @@ Prisma 설정:
 적용 내용:
 
 - 코어 테이블 생성 + FK/조회 인덱스
-- `weapon_ideas`, `skill_ideas`, `perk_ideas`, `gladiator_name_ideas`에 RLS 활성화
-- owner 접근 정책
-- `admin/editor` 팀 역할 정책(weapon 기준 baseline)
+- 앱 레이어 권한 제어를 전제로 DB 레벨의 Supabase Auth/RLS 정책은 포함하지 않음
 
 성능 가이드:
 
-- 정책식에서 `auth.uid()`는 `(select auth.uid())` 형태 사용
-- policy 조건 컬럼(`created_by_id`, `user_id`, `role_id`) 인덱스 동반 여부 확인
+- 권한 필터에 자주 쓰는 컬럼(`created_by_id`, `user_id`, `role_id`) 인덱스 동반 여부 확인
 
 ## 7. 테스트
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:seed": "prisma db seed"
   },
   "dependencies": {
@@ -25,7 +26,8 @@
     "next": "16.2.2",
     "pg": "^8.20.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@kurateh/eslint-plugin": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@kurateh/eslint-plugin':
         specifier: ^2.0.0

--- a/prisma/migrations/20260403162000_platform_foundation/migration.sql
+++ b/prisma/migrations/20260403162000_platform_foundation/migration.sql
@@ -145,56 +145,5 @@ ALTER TABLE "public"."gladiator_name_ideas"
 ADD CONSTRAINT "gladiator_name_ideas_created_by_id_fkey"
 FOREIGN KEY ("created_by_id") REFERENCES "public"."user_profiles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
--- RLS skeleton on core tables
-ALTER TABLE "public"."weapon_ideas" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "public"."skill_ideas" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "public"."perk_ideas" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "public"."gladiator_name_ideas" ENABLE ROW LEVEL SECURITY;
-
--- Owner-only policy
-CREATE POLICY "weapon_ideas_owner_access" ON "public"."weapon_ideas"
-FOR ALL
-TO authenticated
-USING ((select auth.uid()) = created_by_id)
-WITH CHECK ((select auth.uid()) = created_by_id);
-
-CREATE POLICY "skill_ideas_owner_access" ON "public"."skill_ideas"
-FOR ALL
-TO authenticated
-USING ((select auth.uid()) = created_by_id)
-WITH CHECK ((select auth.uid()) = created_by_id);
-
-CREATE POLICY "perk_ideas_owner_access" ON "public"."perk_ideas"
-FOR ALL
-TO authenticated
-USING ((select auth.uid()) = created_by_id)
-WITH CHECK ((select auth.uid()) = created_by_id);
-
-CREATE POLICY "gladiator_name_ideas_owner_access" ON "public"."gladiator_name_ideas"
-FOR ALL
-TO authenticated
-USING ((select auth.uid()) = created_by_id)
-WITH CHECK ((select auth.uid()) = created_by_id);
-
--- Team role baseline policy (admin/editor)
-CREATE POLICY "weapon_ideas_team_role_access" ON "public"."weapon_ideas"
-FOR ALL
-TO authenticated
-USING (
-  EXISTS (
-    SELECT 1
-    FROM "public"."user_roles" ur
-    JOIN "public"."roles" r ON r.id = ur.role_id
-    WHERE ur.user_id = (select auth.uid())
-      AND r.name IN ('admin', 'editor')
-  )
-)
-WITH CHECK (
-  EXISTS (
-    SELECT 1
-    FROM "public"."user_roles" ur
-    JOIN "public"."roles" r ON r.id = ur.role_id
-    WHERE ur.user_id = (select auth.uid())
-      AND r.name IN ('admin', 'editor')
-  )
-);
+-- Note: RLS/auth-schema policies intentionally omitted.
+-- Access control is enforced at the application layer.

--- a/prisma/migrations/20260403212000_battle_situations_core/migration.sql
+++ b/prisma/migrations/20260403212000_battle_situations_core/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "public"."battle_situations" (
+    "id" TEXT NOT NULL,
+    "title" TEXT,
+    "scene_json" JSONB NOT NULL,
+    "semantic_json" JSONB NOT NULL,
+    "created_by_id" UUID NOT NULL,
+    "updated_by_id" UUID NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+    "deleted_by_id" UUID,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "battle_situations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "battle_situations_created_by_id_idx" ON "public"."battle_situations"("created_by_id");
+
+-- CreateIndex
+CREATE INDEX "battle_situations_deleted_at_idx" ON "public"."battle_situations"("deleted_at");
+
+-- CreateIndex
+CREATE INDEX "battle_situations_updated_at_idx" ON "public"."battle_situations"("updated_at");
+
+-- AddForeignKey
+ALTER TABLE "public"."battle_situations"
+ADD CONSTRAINT "battle_situations_created_by_id_fkey"
+FOREIGN KEY ("created_by_id") REFERENCES "public"."user_profiles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."battle_situations"
+ADD CONSTRAINT "battle_situations_updated_by_id_fkey"
+FOREIGN KEY ("updated_by_id") REFERENCES "public"."user_profiles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."battle_situations"
+ADD CONSTRAINT "battle_situations_deleted_by_id_fkey"
+FOREIGN KEY ("deleted_by_id") REFERENCES "public"."user_profiles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Note: RLS/auth-schema policies intentionally omitted.
+-- Access control is enforced at the application layer.

--- a/prisma/migrations/20260403220000_remove_battle_situations_deleted_fields/migration.sql
+++ b/prisma/migrations/20260403220000_remove_battle_situations_deleted_fields/migration.sql
@@ -1,0 +1,9 @@
+-- Drop deleted-field foreign key/index/columns from battle_situations
+ALTER TABLE "public"."battle_situations"
+DROP CONSTRAINT IF EXISTS "battle_situations_deleted_by_id_fkey";
+
+DROP INDEX IF EXISTS "public"."battle_situations_deleted_at_idx";
+
+ALTER TABLE "public"."battle_situations"
+DROP COLUMN IF EXISTS "deleted_by_id",
+DROP COLUMN IF EXISTS "deleted_at";

--- a/prisma/migrations/20260403223000_remove_idea_deleted_fields/migration.sql
+++ b/prisma/migrations/20260403223000_remove_idea_deleted_fields/migration.sql
@@ -1,0 +1,17 @@
+-- Remove deleted fields from idea tables
+DROP INDEX IF EXISTS "public"."weapon_ideas_deleted_at_idx";
+DROP INDEX IF EXISTS "public"."skill_ideas_deleted_at_idx";
+DROP INDEX IF EXISTS "public"."perk_ideas_deleted_at_idx";
+DROP INDEX IF EXISTS "public"."gladiator_name_ideas_deleted_at_idx";
+
+ALTER TABLE "public"."weapon_ideas"
+DROP COLUMN IF EXISTS "deleted_at";
+
+ALTER TABLE "public"."skill_ideas"
+DROP COLUMN IF EXISTS "deleted_at";
+
+ALTER TABLE "public"."perk_ideas"
+DROP COLUMN IF EXISTS "deleted_at";
+
+ALTER TABLE "public"."gladiator_name_ideas"
+DROP COLUMN IF EXISTS "deleted_at";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model UserProfile {
   skillIdeas          SkillIdea[]          @relation("SkillIdeaCreatedBy")
   perkIdeas           PerkIdea[]           @relation("PerkIdeaCreatedBy")
   gladiatorNameIdeas  GladiatorNameIdea[]  @relation("GladiatorNameIdeaCreatedBy")
+  battleSituationsCreated BattleSituation[] @relation("BattleSituationCreatedBy")
+  battleSituationsUpdated BattleSituation[] @relation("BattleSituationUpdatedBy")
 
   @@map("user_profiles")
 }
@@ -56,13 +58,11 @@ model WeaponIdea {
   description String?     @db.Text
   createdAt   DateTime    @default(now()) @map("created_at")
   updatedAt   DateTime    @updatedAt @map("updated_at")
-  deletedAt   DateTime?   @map("deleted_at")
   createdById String      @db.Uuid @map("created_by_id")
 
   createdBy UserProfile @relation("WeaponIdeaCreatedBy", fields: [createdById], references: [id])
 
   @@index([createdById], map: "weapon_ideas_created_by_id_idx")
-  @@index([deletedAt], map: "weapon_ideas_deleted_at_idx")
   @@map("weapon_ideas")
 }
 
@@ -72,13 +72,11 @@ model SkillIdea {
   description String?     @db.Text
   createdAt   DateTime    @default(now()) @map("created_at")
   updatedAt   DateTime    @updatedAt @map("updated_at")
-  deletedAt   DateTime?   @map("deleted_at")
   createdById String      @db.Uuid @map("created_by_id")
 
   createdBy UserProfile @relation("SkillIdeaCreatedBy", fields: [createdById], references: [id])
 
   @@index([createdById], map: "skill_ideas_created_by_id_idx")
-  @@index([deletedAt], map: "skill_ideas_deleted_at_idx")
   @@map("skill_ideas")
 }
 
@@ -88,13 +86,11 @@ model PerkIdea {
   description String?     @db.Text
   createdAt   DateTime    @default(now()) @map("created_at")
   updatedAt   DateTime    @updatedAt @map("updated_at")
-  deletedAt   DateTime?   @map("deleted_at")
   createdById String      @db.Uuid @map("created_by_id")
 
   createdBy UserProfile @relation("PerkIdeaCreatedBy", fields: [createdById], references: [id])
 
   @@index([createdById], map: "perk_ideas_created_by_id_idx")
-  @@index([deletedAt], map: "perk_ideas_deleted_at_idx")
   @@map("perk_ideas")
 }
 
@@ -104,12 +100,28 @@ model GladiatorNameIdea {
   description String?     @db.Text
   createdAt   DateTime    @default(now()) @map("created_at")
   updatedAt   DateTime    @updatedAt @map("updated_at")
-  deletedAt   DateTime?   @map("deleted_at")
   createdById String      @db.Uuid @map("created_by_id")
 
   createdBy UserProfile @relation("GladiatorNameIdeaCreatedBy", fields: [createdById], references: [id])
 
   @@index([createdById], map: "gladiator_name_ideas_created_by_id_idx")
-  @@index([deletedAt], map: "gladiator_name_ideas_deleted_at_idx")
   @@map("gladiator_name_ideas")
+}
+
+model BattleSituation {
+  id           String    @id @default(cuid())
+  title        String?   @db.Text
+  sceneJson    Json      @map("scene_json")
+  semanticJson Json      @map("semantic_json")
+  createdById  String    @db.Uuid @map("created_by_id")
+  updatedById  String    @db.Uuid @map("updated_by_id")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  createdBy UserProfile @relation("BattleSituationCreatedBy", fields: [createdById], references: [id])
+  updatedBy UserProfile @relation("BattleSituationUpdatedBy", fields: [updatedById], references: [id])
+
+  @@index([createdById], map: "battle_situations_created_by_id_idx")
+  @@index([updatedAt], map: "battle_situations_updated_at_idx")
+  @@map("battle_situations")
 }

--- a/src/app/api/battle-situations/[id]/export/route.ts
+++ b/src/app/api/battle-situations/[id]/export/route.ts
@@ -1,0 +1,11 @@
+import { createServerBattleSituationHttpHandlers } from "~/lib/battle-situations/server";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const handlers = await createServerBattleSituationHttpHandlers();
+
+  return handlers.exportById(id);
+}

--- a/src/app/api/battle-situations/[id]/route.ts
+++ b/src/app/api/battle-situations/[id]/route.ts
@@ -1,0 +1,31 @@
+import { createServerBattleSituationHttpHandlers } from "~/lib/battle-situations/server";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const handlers = await createServerBattleSituationHttpHandlers();
+
+  return handlers.getById(id);
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const handlers = await createServerBattleSituationHttpHandlers();
+
+  return handlers.update(id, request);
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const handlers = await createServerBattleSituationHttpHandlers();
+
+  return handlers.remove(id);
+}

--- a/src/app/api/battle-situations/import/route.ts
+++ b/src/app/api/battle-situations/import/route.ts
@@ -1,0 +1,7 @@
+import { createServerBattleSituationHttpHandlers } from "~/lib/battle-situations/server";
+
+export async function POST(request: Request) {
+  const handlers = await createServerBattleSituationHttpHandlers();
+
+  return handlers.importPayload(request);
+}

--- a/src/app/api/battle-situations/route.ts
+++ b/src/app/api/battle-situations/route.ts
@@ -1,0 +1,11 @@
+import { createServerBattleSituationHttpHandlers } from "~/lib/battle-situations/server";
+
+export async function GET() {
+  const handlers = await createServerBattleSituationHttpHandlers();
+  return handlers.list();
+}
+
+export async function POST(request: Request) {
+  const handlers = await createServerBattleSituationHttpHandlers();
+  return handlers.create(request);
+}

--- a/src/lib/battle-situations/http.test.ts
+++ b/src/lib/battle-situations/http.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import type { AccessService } from "~/lib/authz/access-service";
+import { AuthzError } from "~/lib/authz/guards";
+
+import { createBattleSituationHttpHandlers } from "./http";
+import { BattleSituationError, type BattleSituationService } from "./service";
+
+function createAccessServiceStub(
+  overrides: Partial<AccessService> = {},
+): AccessService {
+  return {
+    async getAccess() {
+      return {
+        ok: true,
+        value: {
+          user: { id: "user-1", email: "user-1@datavault.local" },
+          roles: ["editor"],
+        },
+      };
+    },
+    async requireAccess() {
+      return {
+        user: { id: "user-1", email: "user-1@datavault.local" },
+        roles: ["editor"],
+      };
+    },
+    ...overrides,
+  };
+}
+
+function createBattleSituationServiceStub(
+  overrides: Partial<BattleSituationService> = {},
+): BattleSituationService {
+  return {
+    async list() {
+      return [];
+    },
+    async getById(id) {
+      return {
+        id,
+        title: "arena",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+        createdById: "user-1",
+        updatedById: "user-1",
+        createdAt: new Date("2026-04-03T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      };
+    },
+    async create() {
+      return {
+        id: "bs-1",
+        title: "arena",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+        createdById: "user-1",
+        updatedById: "user-1",
+        createdAt: new Date("2026-04-03T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      };
+    },
+    async update() {
+      return {
+        id: "bs-1",
+        title: "arena-updated",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+        createdById: "user-1",
+        updatedById: "user-1",
+        createdAt: new Date("2026-04-03T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      };
+    },
+    async remove() {
+      return {
+        id: "bs-1",
+        title: "arena",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+        createdById: "user-1",
+        updatedById: "user-1",
+        createdAt: new Date("2026-04-03T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-03T01:00:00.000Z"),
+      };
+    },
+    async exportById() {
+      return {
+        meta: {
+          id: "bs-1",
+          schemaVersion: 1,
+          exportedAt: "2026-04-03T01:00:00.000Z",
+        },
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+      };
+    },
+    async importPayload() {
+      return {
+        id: "bs-2",
+        title: "imported",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+        createdById: "user-1",
+        updatedById: "user-1",
+        createdAt: new Date("2026-04-03T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      };
+    },
+    ...overrides,
+  };
+}
+
+describe("createBattleSituationHttpHandlers", () => {
+  it("returns 201 for create when authorized", async () => {
+    const handlers = createBattleSituationHttpHandlers({
+      accessService: createAccessServiceStub(),
+      battleSituationService: createBattleSituationServiceStub(),
+    });
+
+    const request = new Request("http://localhost/api/battle-situations", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "arena",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    const response = await handlers.create(request);
+
+    expect(response.status).toBe(201);
+    const payload = await response.json();
+    expect(payload.ok).toBe(true);
+    expect(payload.data.id).toBe("bs-1");
+  });
+
+  it("returns 401 when access service raises unauthenticated", async () => {
+    const handlers = createBattleSituationHttpHandlers({
+      accessService: createAccessServiceStub({
+        async requireAccess() {
+          throw new AuthzError("UNAUTHENTICATED", "Login required");
+        },
+      }),
+      battleSituationService: createBattleSituationServiceStub(),
+    });
+
+    const request = new Request("http://localhost/api/battle-situations", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "arena",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    const response = await handlers.create(request);
+
+    expect(response.status).toBe(401);
+    const payload = await response.json();
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("UNAUTHENTICATED");
+  });
+
+  it("returns 403 when update is forbidden for ownership", async () => {
+    const handlers = createBattleSituationHttpHandlers({
+      accessService: createAccessServiceStub(),
+      battleSituationService: createBattleSituationServiceStub({
+        async update() {
+          throw new BattleSituationError("FORBIDDEN", "cannot edit");
+        },
+      }),
+    });
+
+    const request = new Request("http://localhost/api/battle-situations/bs-1", {
+      method: "PATCH",
+      body: JSON.stringify({
+        title: "arena-updated",
+        sceneJson: { units: [] },
+        semanticJson: { allies: [], enemies: [] },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    const response = await handlers.update("bs-1", request);
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 when payload validation fails", async () => {
+    const handlers = createBattleSituationHttpHandlers({
+      accessService: createAccessServiceStub(),
+      battleSituationService: createBattleSituationServiceStub({
+        async create() {
+          throw new BattleSituationError("INVALID_PAYLOAD", "bad payload", [
+            "sceneJson must be an object.",
+          ]);
+        },
+      }),
+    });
+
+    const request = new Request("http://localhost/api/battle-situations", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "arena",
+        sceneJson: [],
+        semanticJson: { allies: [], enemies: [] },
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    const response = await handlers.create(request);
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("INVALID_PAYLOAD");
+    expect(payload.details).toEqual(["sceneJson must be an object."]);
+  });
+});

--- a/src/lib/battle-situations/http.ts
+++ b/src/lib/battle-situations/http.ts
@@ -1,0 +1,156 @@
+import type { AccessService } from "~/lib/authz/access-service";
+import { AuthzError } from "~/lib/authz/guards";
+import { rolesForPolicy } from "~/lib/authz/policy";
+
+import { BattleSituationError, type BattleSituationService } from "./service";
+
+type CreateBattleSituationHttpHandlersDeps = {
+  accessService: AccessService;
+  battleSituationService: BattleSituationService;
+};
+
+export function createBattleSituationHttpHandlers(
+  deps: CreateBattleSituationHttpHandlersDeps,
+) {
+  return {
+    async list() {
+      try {
+        await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const rows = await deps.battleSituationService.list();
+        return Response.json({ ok: true, data: rows });
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async getById(id: string) {
+      try {
+        await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const row = await deps.battleSituationService.getById(id);
+        return Response.json({ ok: true, data: row });
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async create(request: Request) {
+      try {
+        const ctx = await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const body = await request.json();
+        const row = await deps.battleSituationService.create(ctx, body);
+
+        return Response.json(
+          {
+            ok: true,
+            data: row,
+          },
+          {
+            status: 201,
+          },
+        );
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async update(id: string, request: Request) {
+      try {
+        const ctx = await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const body = await request.json();
+        const row = await deps.battleSituationService.update(ctx, id, body);
+
+        return Response.json({
+          ok: true,
+          data: row,
+        });
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async remove(id: string) {
+      try {
+        const ctx = await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const row = await deps.battleSituationService.remove(ctx, id);
+
+        return Response.json({
+          ok: true,
+          data: row,
+        });
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async exportById(id: string) {
+      try {
+        await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const payload = await deps.battleSituationService.exportById(id);
+
+        return Response.json({
+          ok: true,
+          data: payload,
+        });
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+    async importPayload(request: Request) {
+      try {
+        const ctx = await deps.accessService.requireAccess(
+          rolesForPolicy("platformAccess"),
+        );
+        const body = await request.json();
+        const row = await deps.battleSituationService.importPayload(ctx, body);
+
+        return Response.json(
+          {
+            ok: true,
+            data: row,
+          },
+          {
+            status: 201,
+          },
+        );
+      } catch (error) {
+        return toErrorResponse(error);
+      }
+    },
+  };
+}
+
+function toErrorResponse(error: unknown): Response {
+  if (error instanceof AuthzError) {
+    return Response.json(
+      {
+        ok: false,
+        error: error.code,
+      },
+      {
+        status: error.status,
+      },
+    );
+  }
+
+  if (error instanceof BattleSituationError) {
+    return Response.json(
+      {
+        ok: false,
+        error: error.code,
+        details: error.details,
+      },
+      {
+        status: error.status,
+      },
+    );
+  }
+
+  throw error;
+}

--- a/src/lib/battle-situations/repository.ts
+++ b/src/lib/battle-situations/repository.ts
@@ -1,0 +1,76 @@
+import type { Prisma, PrismaClient } from "~/generated/prisma/client";
+import { prisma } from "~/lib/prisma";
+
+import type {
+  BattleSituationRecord,
+  BattleSituationRepository,
+} from "./service";
+
+type BattleSituationQueryClient = Pick<PrismaClient, "battleSituation">;
+
+export function createBattleSituationRepository(
+  db: BattleSituationQueryClient = prisma,
+): BattleSituationRepository {
+  return {
+    async listActive() {
+      const rows = await db.battleSituation.findMany({
+        orderBy: {
+          updatedAt: "desc",
+        },
+      });
+
+      return rows.map(toRecord);
+    },
+    async findById(id) {
+      const row = await db.battleSituation.findUnique({
+        where: { id },
+      });
+      return row ? toRecord(row) : null;
+    },
+    async create(input) {
+      const row = await db.battleSituation.create({
+        data: {
+          title: input.title ?? null,
+          sceneJson: input.sceneJson as Prisma.InputJsonValue,
+          semanticJson: input.semanticJson as Prisma.InputJsonValue,
+          createdById: input.createdById,
+          updatedById: input.updatedById,
+        },
+      });
+      return toRecord(row);
+    },
+    async update(input) {
+      const row = await db.battleSituation.update({
+        where: { id: input.id },
+        data: {
+          title: input.title ?? null,
+          sceneJson: input.sceneJson as Prisma.InputJsonValue,
+          semanticJson: input.semanticJson as Prisma.InputJsonValue,
+          updatedById: input.updatedById,
+        },
+      });
+      return toRecord(row);
+    },
+    async deleteById(input) {
+      const row = await db.battleSituation.delete({
+        where: { id: input.id },
+      });
+      return toRecord(row);
+    },
+  };
+}
+
+function toRecord(
+  row: Prisma.BattleSituationGetPayload<object>,
+): BattleSituationRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    sceneJson: row.sceneJson as Record<string, unknown>,
+    semanticJson: row.semanticJson as Record<string, unknown>,
+    createdById: row.createdById,
+    updatedById: row.updatedById,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/src/lib/battle-situations/server.ts
+++ b/src/lib/battle-situations/server.ts
@@ -1,0 +1,18 @@
+import { createServerAccessService } from "~/lib/authz/access-service";
+
+import { createBattleSituationHttpHandlers } from "./http";
+import { createBattleSituationRepository } from "./repository";
+import { createBattleSituationService } from "./service";
+
+export async function createServerBattleSituationHttpHandlers() {
+  const accessService = await createServerAccessService();
+  const repository = createBattleSituationRepository();
+  const battleSituationService = createBattleSituationService({
+    repository,
+  });
+
+  return createBattleSituationHttpHandlers({
+    accessService,
+    battleSituationService,
+  });
+}

--- a/src/lib/battle-situations/service.test.ts
+++ b/src/lib/battle-situations/service.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthContext } from "~/lib/authz/guards";
+
+import {
+  BattleSituationError,
+  createBattleSituationService,
+  type BattleSituationRecord,
+  type BattleSituationRepository,
+} from "./service";
+
+function makeAuthContext(
+  userId: string,
+  roles: AuthContext["roles"],
+): AuthContext {
+  return {
+    user: { id: userId, email: `${userId}@data-vault.local` },
+    roles,
+  };
+}
+
+function createInMemoryRepository(
+  seed: BattleSituationRecord[] = [],
+): BattleSituationRepository {
+  const items = [...seed];
+
+  return {
+    async listActive() {
+      return items;
+    },
+    async findById(id) {
+      return items.find((item) => item.id === id) ?? null;
+    },
+    async create(input) {
+      const row: BattleSituationRecord = {
+        id: `bs-${items.length + 1}`,
+        title: input.title ?? null,
+        sceneJson: input.sceneJson,
+        semanticJson: input.semanticJson,
+        createdById: input.createdById,
+        updatedById: input.updatedById,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      items.push(row);
+      return row;
+    },
+    async update(input) {
+      const current = items.find((item) => item.id === input.id);
+
+      if (!current) {
+        throw new BattleSituationError("NOT_FOUND", "not found");
+      }
+
+      const updated: BattleSituationRecord = {
+        ...current,
+        title: input.title ?? null,
+        sceneJson: input.sceneJson,
+        semanticJson: input.semanticJson,
+        updatedById: input.updatedById,
+        updatedAt: new Date(),
+      };
+      const index = items.findIndex((item) => item.id === input.id);
+      items[index] = updated;
+
+      return updated;
+    },
+    async deleteById(input) {
+      const current = items.find((item) => item.id === input.id);
+
+      if (!current) {
+        throw new BattleSituationError("NOT_FOUND", "not found");
+      }
+      const index = items.findIndex((item) => item.id === input.id);
+      items.splice(index, 1);
+
+      return current;
+    },
+  };
+}
+
+describe("createBattleSituationService", () => {
+  it("creates a battle situation with scene_json and semantic_json", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository(),
+    });
+
+    const result = await service.create(makeAuthContext("user-1", ["editor"]), {
+      sceneJson: { units: [{ id: "a-1" }] },
+      semanticJson: { allies: [{ id: "a-1" }], enemies: [] },
+      title: "Arena alpha",
+    });
+
+    expect(result.id).toBeTypeOf("string");
+    expect(result.sceneJson).toEqual({ units: [{ id: "a-1" }] });
+    expect(result.semanticJson).toEqual({
+      allies: [{ id: "a-1" }],
+      enemies: [],
+    });
+    expect(result.createdById).toBe("user-1");
+    expect(result.updatedById).toBe("user-1");
+  });
+
+  it("allows editor to update own battle situation", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "before",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [], enemies: [] },
+          createdById: "user-1",
+          updatedById: "user-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    const updated = await service.update(
+      makeAuthContext("user-1", ["editor"]),
+      "bs-1",
+      {
+        title: "after",
+        sceneJson: { units: [{ id: "u-1" }, { id: "u-2" }] },
+        semanticJson: { allies: [{ id: "u-1" }], enemies: [{ id: "u-2" }] },
+      },
+    );
+
+    expect(updated.title).toBe("after");
+    expect(updated.updatedById).toBe("user-1");
+    expect(updated.sceneJson).toEqual({
+      units: [{ id: "u-1" }, { id: "u-2" }],
+    });
+  });
+
+  it("rejects editor update on another user's battle situation", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "before",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [], enemies: [] },
+          createdById: "owner-1",
+          updatedById: "owner-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    await expect(() =>
+      service.update(makeAuthContext("user-2", ["editor"]), "bs-1", {
+        title: "after",
+        sceneJson: { units: [{ id: "u-1" }, { id: "u-2" }] },
+        semanticJson: { allies: [{ id: "u-1" }], enemies: [{ id: "u-2" }] },
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      status: 403,
+    });
+  });
+
+  it("allows admin to update another user's battle situation", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "before",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [], enemies: [] },
+          createdById: "owner-1",
+          updatedById: "owner-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    const updated = await service.update(
+      makeAuthContext("admin-1", ["admin"]),
+      "bs-1",
+      {
+        title: "admin-updated",
+        sceneJson: { units: [{ id: "u-9" }] },
+        semanticJson: { allies: [{ id: "u-9" }], enemies: [] },
+      },
+    );
+
+    expect(updated.title).toBe("admin-updated");
+    expect(updated.updatedById).toBe("admin-1");
+  });
+
+  it("allows editor to delete own battle situation", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "before",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [], enemies: [] },
+          createdById: "user-1",
+          updatedById: "user-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    const deleted = await service.remove(
+      makeAuthContext("user-1", ["editor"]),
+      "bs-1",
+    );
+
+    expect(deleted.id).toBe("bs-1");
+    expect(deleted.createdById).toBe("user-1");
+  });
+
+  it("rejects editor delete on another user's battle situation", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "before",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [], enemies: [] },
+          createdById: "owner-1",
+          updatedById: "owner-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    await expect(() =>
+      service.remove(makeAuthContext("user-2", ["editor"]), "bs-1"),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      status: 403,
+    });
+  });
+
+  it("exports battle situation json with meta", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository([
+        {
+          id: "bs-1",
+          title: "arena-export",
+          sceneJson: { units: [{ id: "u-1" }] },
+          semanticJson: { allies: [{ id: "u-1" }], enemies: [] },
+          createdById: "owner-1",
+          updatedById: "owner-1",
+          createdAt: new Date("2026-04-03T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    const exported = await service.exportById("bs-1");
+
+    expect(exported.meta.id).toBe("bs-1");
+    expect(exported.meta.schemaVersion).toBe(1);
+    expect(exported.sceneJson).toEqual({ units: [{ id: "u-1" }] });
+    expect(exported.semanticJson).toEqual({
+      allies: [{ id: "u-1" }],
+      enemies: [],
+    });
+  });
+
+  it("imports battle situation json as a new record", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository(),
+    });
+
+    const imported = await service.importPayload(
+      makeAuthContext("user-1", ["editor"]),
+      {
+        sceneJson: { units: [{ id: "u-1" }] },
+        semanticJson: { allies: [{ id: "u-1" }], enemies: [] },
+        title: "imported arena",
+      },
+    );
+
+    expect(imported.id).toBeTypeOf("string");
+    expect(imported.title).toBe("imported arena");
+    expect(imported.createdById).toBe("user-1");
+  });
+
+  it("rejects invalid payload when scene_json is not an object", async () => {
+    const service = createBattleSituationService({
+      repository: createInMemoryRepository(),
+    });
+
+    await expect(() =>
+      service.create(makeAuthContext("user-1", ["editor"]), {
+        title: "invalid payload",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        sceneJson: [] as any,
+        semanticJson: { allies: [], enemies: [] },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_PAYLOAD",
+      status: 400,
+    });
+  });
+});

--- a/src/lib/battle-situations/service.ts
+++ b/src/lib/battle-situations/service.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+
+import type { AuthContext } from "~/lib/authz/guards";
+
+type JsonObject = Record<string, unknown>;
+
+export type BattleSituationRecord = {
+  id: string;
+  title: string | null;
+  sceneJson: JsonObject;
+  semanticJson: JsonObject;
+  createdById: string;
+  updatedById: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type CreateBattleSituationInput = {
+  title?: string | null;
+  sceneJson: JsonObject;
+  semanticJson: JsonObject;
+  createdById: string;
+  updatedById: string;
+};
+
+type UpdateBattleSituationInput = {
+  id: string;
+  title?: string | null;
+  sceneJson: JsonObject;
+  semanticJson: JsonObject;
+  updatedById: string;
+};
+
+type DeleteBattleSituationInput = {
+  id: string;
+};
+
+export type BattleSituationRepository = {
+  listActive: () => Promise<BattleSituationRecord[]>;
+  findById: (id: string) => Promise<BattleSituationRecord | null>;
+  create: (input: CreateBattleSituationInput) => Promise<BattleSituationRecord>;
+  update: (input: UpdateBattleSituationInput) => Promise<BattleSituationRecord>;
+  deleteById: (
+    input: DeleteBattleSituationInput,
+  ) => Promise<BattleSituationRecord>;
+};
+
+export class BattleSituationError extends Error {
+  code: "FORBIDDEN" | "NOT_FOUND" | "INVALID_PAYLOAD";
+  status: number;
+  details?: string[];
+
+  constructor(
+    code: "FORBIDDEN" | "NOT_FOUND" | "INVALID_PAYLOAD",
+    message: string,
+    details?: string[],
+  ) {
+    super(message);
+    this.code = code;
+    this.status =
+      code === "INVALID_PAYLOAD" ? 400 : code === "NOT_FOUND" ? 404 : 403;
+    this.name = "BattleSituationError";
+    this.details = details;
+  }
+}
+
+type CreateBattleSituationPayload = {
+  title?: string | null;
+  sceneJson: JsonObject;
+  semanticJson: JsonObject;
+};
+
+const JsonObjectSchema = z.custom<JsonObject>(
+  (value) =>
+    typeof value === "object" && value !== null && !Array.isArray(value),
+  {
+    message: "must be an object.",
+  },
+);
+
+const CreateBattleSituationPayloadSchema = z.object({
+  title: z.string().nullable().optional(),
+  sceneJson: JsonObjectSchema,
+  semanticJson: JsonObjectSchema,
+});
+
+type CreateBattleSituationServiceDeps = {
+  repository: BattleSituationRepository;
+};
+
+export type BattleSituationService = {
+  list: () => Promise<BattleSituationRecord[]>;
+  getById: (id: string) => Promise<BattleSituationRecord>;
+  create: (
+    auth: AuthContext,
+    payload: CreateBattleSituationPayload,
+  ) => Promise<BattleSituationRecord>;
+  update: (
+    auth: AuthContext,
+    id: string,
+    payload: CreateBattleSituationPayload,
+  ) => Promise<BattleSituationRecord>;
+  remove: (auth: AuthContext, id: string) => Promise<BattleSituationRecord>;
+  exportById: (id: string) => Promise<{
+    meta: {
+      id: string;
+      schemaVersion: number;
+      exportedAt: string;
+    };
+    sceneJson: JsonObject;
+    semanticJson: JsonObject;
+  }>;
+  importPayload: (
+    auth: AuthContext,
+    payload: CreateBattleSituationPayload,
+  ) => Promise<BattleSituationRecord>;
+};
+
+export function createBattleSituationService(
+  deps: CreateBattleSituationServiceDeps,
+): BattleSituationService {
+  return {
+    async list() {
+      return deps.repository.listActive();
+    },
+    async getById(id) {
+      const current = await deps.repository.findById(id);
+
+      if (!current) {
+        throw new BattleSituationError(
+          "NOT_FOUND",
+          "Battle situation was not found.",
+        );
+      }
+
+      return current;
+    },
+    async create(auth, payload) {
+      validatePayload(payload);
+
+      return deps.repository.create({
+        title: payload.title ?? null,
+        sceneJson: payload.sceneJson,
+        semanticJson: payload.semanticJson,
+        createdById: auth.user.id,
+        updatedById: auth.user.id,
+      });
+    },
+    async update(auth, id, payload) {
+      validatePayload(payload);
+
+      const current = await deps.repository.findById(id);
+
+      if (!current) {
+        throw new BattleSituationError(
+          "NOT_FOUND",
+          "Battle situation was not found.",
+        );
+      }
+
+      if (!canMutate(auth, current.createdById)) {
+        throw new BattleSituationError(
+          "FORBIDDEN",
+          "You cannot edit this battle situation.",
+        );
+      }
+
+      return deps.repository.update({
+        id,
+        title: payload.title ?? null,
+        sceneJson: payload.sceneJson,
+        semanticJson: payload.semanticJson,
+        updatedById: auth.user.id,
+      });
+    },
+    async remove(auth, id) {
+      const current = await deps.repository.findById(id);
+
+      if (!current) {
+        throw new BattleSituationError(
+          "NOT_FOUND",
+          "Battle situation was not found.",
+        );
+      }
+
+      if (!canMutate(auth, current.createdById)) {
+        throw new BattleSituationError(
+          "FORBIDDEN",
+          "You cannot delete this battle situation.",
+        );
+      }
+
+      return deps.repository.deleteById({
+        id,
+      });
+    },
+    async exportById(id) {
+      const current = await deps.repository.findById(id);
+
+      if (!current) {
+        throw new BattleSituationError(
+          "NOT_FOUND",
+          "Battle situation was not found.",
+        );
+      }
+
+      return {
+        meta: {
+          id: current.id,
+          schemaVersion: 1,
+          exportedAt: new Date().toISOString(),
+        },
+        sceneJson: current.sceneJson,
+        semanticJson: current.semanticJson,
+      };
+    },
+    async importPayload(auth, payload) {
+      validatePayload(payload);
+
+      return deps.repository.create({
+        title: payload.title ?? null,
+        sceneJson: payload.sceneJson,
+        semanticJson: payload.semanticJson,
+        createdById: auth.user.id,
+        updatedById: auth.user.id,
+      });
+    },
+  };
+}
+
+function validatePayload(payload: CreateBattleSituationPayload): void {
+  const parsed = CreateBattleSituationPayloadSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((issue) => {
+      const key =
+        issue.path.length > 0 && typeof issue.path[0] === "string"
+          ? issue.path[0]
+          : "payload";
+      return `${key} ${issue.message}`;
+    });
+
+    throw new BattleSituationError(
+      "INVALID_PAYLOAD",
+      "Payload validation failed.",
+      errors,
+    );
+  }
+}
+
+function canMutate(auth: AuthContext, ownerId: string): boolean {
+  if (auth.roles.includes("admin")) {
+    return true;
+  }
+
+  if (auth.roles.includes("editor") && auth.user.id === ownerId) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## 변경 요약
### Issue #9 핵심
- `battle_situations` 코어 스키마 및 마이그레이션 추가
- `/api/battle-situations` CRUD + import/export 라우트 추가
- 전장 데이터 `scene_json` + `semantic_json` 저장 지원
- 권한 정책 적용: `admin` 전체 수정/삭제, `editor` 본인 생성 건만 수정/삭제
- Battle Situation payload 검증을 `zod` 기반으로 적용

### 구현 구성
- 도메인 서비스/레포지토리/HTTP 핸들러 분리
- 서비스/HTTP 테스트 추가(TDD)

### 추가 정리(요청 반영)
- soft delete 관련 필드 제거 방향으로 스키마 정리
- Supabase-only 운영을 위한 Prisma migrate deploy 중심 스크립트/문서 정리

## 검증
- `pnpm prisma:generate`
- `pnpm type-check`
- `pnpm lint --fix`
- `pnpm test`

Closes #9
